### PR TITLE
Users can delete binary that has comments

### DIFF
--- a/app/models/binary.rb
+++ b/app/models/binary.rb
@@ -4,7 +4,7 @@ class Binary < ApplicationRecord
   validates :data_url, presence: true
 
   belongs_to :folder
-  has_many :comments
+  has_many :comments,  dependent: :destroy
   has_many :likes, as: :likeable
 
   enum status: %w(active inactive)


### PR DESCRIPTION
#### Fixes #146412171

#### What does  this PR do?
Fixes bug where you cant delete binaries that have comments

#### Where should the reviewer start?
Files changed
#### How should this be manually tested?
delete a file that has comments
#### Any background context you want to provide?
n/a
#### Screenshots (if appropriate)

#### Questions:
  - Do Migrations Need to be ran? 
  no
  - Do Environment Variables need to be set? 
  no
  - Any other deploy steps? 
no